### PR TITLE
nnbd versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.0.0-nullsafety] - 2021/01-31
+## [2.0.0-nullsafety.0] - 2021/01-31
 
 * Migrate to null-safety
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pixel_border
 
-[![pub](https://img.shields.io/badge/pub-1.0.0--nullsafety-blue.svg)](https://pub.dev/packages/pixel_border) ![test](https://github.com/aqulu/flutter_pixel_border/workflows/test/badge.svg) ![lint](https://github.com/aqulu/flutter_pixel_border/workflows/lint/badge.svg)
+[![pub](https://img.shields.io/badge/pub-2.0.0--nullsafety.0-blue.svg)](https://pub.dev/packages/pixel_border) ![test](https://github.com/aqulu/flutter_pixel_border/workflows/test/badge.svg) ![lint](https://github.com/aqulu/flutter_pixel_border/workflows/lint/badge.svg)
 
 A package to render shapes or borders of widgets with pixelated corners.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-nullsafety"
+    version: "2.0.0-nullsafety"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pixel_border
 description: A flutter package providing a ShapeBorder to give the shape or border of widgets a pixel-y look.
-version: 1.0.0-nullsafety
+version: 2.0.0-nullsafety.0
 homepage: https://github.com/aqulu/flutter_pixel_border
 
 environment:


### PR DESCRIPTION
follow nnbd package best-practices by bumping major version

ref: https://dart.dev/null-safety/migration-guide#step5-publish