### PR TITLE
Migrate superclass to OutlinedBorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [2.0.0-nullsafety.0] - 2021/01-31
+## [2.0.0-nullsafety.1] - 2021/02/15
+
+* Migrate to OutlinedBorder
+
+## [2.0.0-nullsafety.0] - 2021/01/31
 
 * Migrate to null-safety
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pixel_border
 
-[![pub](https://img.shields.io/badge/pub-2.0.0--nullsafety.0-blue.svg)](https://pub.dev/packages/pixel_border) ![test](https://github.com/aqulu/flutter_pixel_border/workflows/test/badge.svg) ![lint](https://github.com/aqulu/flutter_pixel_border/workflows/lint/badge.svg)
+[![pub](https://img.shields.io/badge/pub-2.0.0--nullsafety.1-blue.svg)](https://pub.dev/packages/pixel_border) ![test](https://github.com/aqulu/flutter_pixel_border/workflows/test/badge.svg) ![lint](https://github.com/aqulu/flutter_pixel_border/workflows/lint/badge.svg)
 
 A package to render shapes or borders of widgets with pixelated corners.
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,17 @@ Container(
 );
 ```
 
-Setting the default button shape in MaterialApp:
+Setting the default ElevatedButton shape in MaterialApp:
 
 ```dart
 MaterialApp(
   theme: ThemeData(
-    buttonTheme: ButtonThemeData(
-      shape: PixelBorder.shape(
-        borderRadius: BorderRadius.circular(10),
-        pixelSize: 5,
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        shape: PixelBorder.shape(
+          borderRadius: BorderRadius.circular(10),
+          pixelSize: 5,
+        ),
       ),
     ),
   ),

--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ Drawing an orange square border where all corners are rounded and drawn with "pi
 ```dart
 Container(
   decoration: ShapeDecoration(
-    shape: PixelBorder(
+    shape: PixelBorder.solid(
       borderRadius: BorderRadius.circular(4.0),
       pixelSize: 2.0,
-      style: BorderStyle.solid,
-      borderColor: Colors.orange,
+      color: Colors.orange,
     ),
   ),
   height: 42.0,
@@ -33,7 +32,7 @@ Setting the default button shape in MaterialApp:
 MaterialApp(
   theme: ThemeData(
     buttonTheme: ButtonThemeData(
-      shape: PixelBorder(
+      shape: PixelBorder.shape(
         borderRadius: BorderRadius.circular(10),
         pixelSize: 5,
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,7 +31,7 @@ class Showcase extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.all(8.0),
                   child: RaisedButton(
-                    shape: PixelBorder(
+                    shape: PixelBorder.shape(
                       borderRadius: BorderRadius.circular(10.0),
                       pixelSize: 5.0,
                     ),
@@ -41,14 +41,13 @@ class Showcase extends StatelessWidget {
                 Container(
                   padding: const EdgeInsets.all(10.0),
                   decoration: ShapeDecoration(
-                    shape: const PixelBorder(
+                    shape: PixelBorder.solid(
                       pixelSize: 2.0,
                       borderRadius: BorderRadius.only(
                         topLeft: Radius.circular(8.0),
                         bottomRight: Radius.circular(16.0),
                       ),
-                      style: BorderStyle.solid,
-                      borderColor: Colors.purple,
+                      color: Colors.purple,
                     ),
                   ),
                   height: 200,
@@ -57,7 +56,7 @@ class Showcase extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.all(10.0),
                   child: Card(
-                    shape: PixelBorder(
+                    shape: PixelBorder.shape(
                       borderRadius: BorderRadius.circular(180.0),
                       pixelSize: 20.0,
                     ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,10 +30,13 @@ class Showcase extends StatelessWidget {
               children: <Widget>[
                 Padding(
                   padding: const EdgeInsets.all(8.0),
-                  child: RaisedButton(
-                    shape: PixelBorder.shape(
-                      borderRadius: BorderRadius.circular(10.0),
-                      pixelSize: 5.0,
+                  child: ElevatedButton(
+                    child: SizedBox.shrink(),
+                    style: ElevatedButton.styleFrom(
+                      shape: PixelBorder.shape(
+                        borderRadius: BorderRadius.circular(10.0),
+                        pixelSize: 5.0,
+                      ),
                     ),
                     onPressed: () {},
                   ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-nullsafety"
+    version: "2.0.0-nullsafety.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-nullsafety.0"
+    version: "2.0.0-nullsafety.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pixel_border
 description: A flutter package providing a ShapeBorder to give the shape or border of widgets a pixel-y look.
-version: 2.0.0-nullsafety.0
+version: 2.0.0-nullsafety.1
 homepage: https://github.com/aqulu/flutter_pixel_border
 
 environment:

--- a/test/pixel_border_test.dart
+++ b/test/pixel_border_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pixel_border/pixel_border.dart';
 
 void main() {
-  test('negative radius are clamped to 0', () {
+  test('negative radii are clamped to 0', () {
     const Rect rect = Rect.fromLTRB(10.0, 20.0, 50.0, 60.0);
 
     final matcher = _PathMatcher(
@@ -11,7 +11,7 @@ void main() {
       [Offset(9.0, 19.0), Offset(51.0, 61.0)],
     );
 
-    const PixelBorder border = PixelBorder(
+    const PixelBorder border = PixelBorder.shape(
       borderRadius: BorderRadius.only(topLeft: Radius.circular(-10)),
       pixelSize: 5.0,
     );
@@ -65,7 +65,7 @@ void main() {
       ],
     );
 
-    const PixelBorder border = PixelBorder(
+    const PixelBorder border = PixelBorder.shape(
       borderRadius: BorderRadius.all(Radius.circular(20.0)),
       pixelSize: 5.0,
     );
@@ -75,15 +75,15 @@ void main() {
   });
 
   test('scaling', () {
-    const halved = PixelBorder(
+    final halved = PixelBorder.shape(
       borderRadius: BorderRadius.all(Radius.circular(5.0)),
       pixelSize: 2.5,
     );
-    const normal = PixelBorder(
+    final normal = PixelBorder.shape(
       borderRadius: BorderRadius.all(Radius.circular(10.0)),
       pixelSize: 5.0,
     );
-    const enlarged = PixelBorder(
+    final enlarged = PixelBorder.shape(
       borderRadius: BorderRadius.all(Radius.circular(15.0)),
       pixelSize: 7.5,
     );
@@ -101,7 +101,7 @@ void main() {
       [Offset(9.0, 19.0), Offset(51.0, 61.0)],
     );
 
-    const PixelBorder border = PixelBorder(
+    const PixelBorder border = PixelBorder.shape(
       borderRadius: BorderRadius.zero,
       pixelSize: 5.0,
     );
@@ -143,7 +143,7 @@ void main() {
       [rect.topLeft, rect.topRight, rect.bottomLeft, rect.bottomRight],
     );
 
-    const PixelBorder border = PixelBorder(
+    const PixelBorder border = PixelBorder.shape(
       borderRadius: BorderRadius.all(Radius.circular(10.0)),
       pixelSize: 5.0,
     );
@@ -155,7 +155,7 @@ void main() {
   test('pixelSize larger than borderRadius', () {
     const Rect rect = Rect.fromLTRB(10.0, 20.0, 50.0, 60.0);
 
-    const PixelBorder border = PixelBorder(
+    const PixelBorder border = PixelBorder.shape(
       borderRadius: BorderRadius.all(Radius.circular(5.0)),
       pixelSize: 10.0,
     );
@@ -173,7 +173,7 @@ void main() {
   test('borderRadius is not multiple of pixelSize', () {
     const Rect rect = Rect.fromLTRB(10.0, 20.0, 50.0, 60.0);
 
-    const PixelBorder border = PixelBorder(
+    const PixelBorder border = PixelBorder.shape(
       borderRadius: BorderRadius.all(Radius.circular(7.0)),
       pixelSize: 5.0,
     );
@@ -215,7 +215,7 @@ void main() {
         ],
       );
 
-      const PixelBorder border = PixelBorder(
+      const PixelBorder border = PixelBorder.shape(
         borderRadius: BorderRadius.all(Radius.circular(200.0)),
         pixelSize: 20.0,
       );
@@ -231,7 +231,7 @@ void main() {
     () {
       const Rect rect = Rect.fromLTRB(10.0, 10.0, 20.0, 20.0);
 
-      const PixelBorder border = PixelBorder(
+      const PixelBorder border = PixelBorder.shape(
         borderRadius: BorderRadius.all(Radius.circular(5.0)),
         pixelSize: 5.0,
       );


### PR DESCRIPTION
### Overview

- Change superclass from ShapeBorder to OutlinedBorder for use with new Material Buttons
- Migrate examples to new Material Buttons (ElevatedButton)